### PR TITLE
fix: avoid Ghostty black screen in image mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ NES Core → RGB framebuffer (256×240×3) → Renderer → Terminal
 
 - Image mode (`renderer: "image"`) runs at ~30fps to keep emulation stable
 - Text mode (`renderer: "text"`) runs at ~60fps in an overlay
-- Image mode uses a windowed overlay (90% width/height) to avoid Kitty full-screen artifacts
+- Image mode runs in the main custom UI instead of an overlay to avoid Ghostty black-screen rendering issues while still using Kitty graphics
 
 ### Session Lifecycle
 
@@ -104,7 +104,7 @@ The addons compile to `index.node`. The JS wrapper (`index.js`) tries to load it
 ## Known Limitations
 
 - **Audio is opt-in** — Requires a native core built with `audio-cpal` and `enableAudio: true`.
-- **Overlay flicker** — Kitty overlay can show a 1-line flicker at overlay boundaries (see issue #9).
+- **Overlay flicker** — Text-mode overlays can show a 1-line flicker at overlay boundaries (see issue #9).
 - **No save states** — Only battery-backed SRAM saves are persisted.
 
 ## Release and Publishing

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Saves are flushed on quit and periodically during play.
 
 **Best experience:** a Kitty-protocol terminal like Ghostty, Kitty, or WezTerm (image protocol + key-up events).
 
-- **Kitty-protocol terminals** — Full graphics via image protocol (shared memory or file transport)
+- **Kitty-protocol terminals** — Full graphics via image protocol (shared memory or file transport). Image mode opens in pi's main custom UI instead of an overlay to avoid Ghostty black-screen rendering issues.
 - **Other terminals** — Falls back to ANSI half-block characters (`▀▄`)
 
-Set `"renderer": "text"` if you prefer the ANSI renderer or have display issues.
+Set `"renderer": "text"` if you prefer the ANSI renderer or want the classic overlay experience.
 
 ## Limitations
 

--- a/extensions/nes/index.ts
+++ b/extensions/nes/index.ts
@@ -397,15 +397,17 @@ async function attachSession(
 	let shouldStop = false;
 	try {
 		const isImageRenderer = config.renderer === "image";
-		const overlayOptions = {
-			overlay: true,
-			overlayOptions: {
-				width: isImageRenderer ? "90%" : "85%",
-				maxHeight: "90%",
-				anchor: "center",
-				margin: { top: 1 },
-			},
-		};
+		const overlayOptions = isImageRenderer
+			? undefined
+			: {
+				overlay: true,
+				overlayOptions: {
+					width: "85%",
+					maxHeight: "90%",
+					anchor: "center",
+					margin: { top: 1 },
+				},
+			};
 
 		const renderIntervalMs = config.renderer === "image"
 			? config.imageQuality === "high"
@@ -414,6 +416,10 @@ async function attachSession(
 			: TEXT_RENDER_INTERVAL_MS;
 		session.setRenderIntervalMs(renderIntervalMs);
 
+		// Image mode must run in the main custom UI instead of an overlay.
+		// Ghostty renders the same Kitty image sequence correctly on its own, but
+		// the pi overlay path can leave the image area black. Text mode still works
+		// well as an overlay, so keep that behavior there.
 		await ctx.ui.custom(
 			(tui, _theme, _keybindings, done) => {
 				session.setRenderHook(() => tui.requestRender());
@@ -452,7 +458,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("nes", {
-		description: "Play NES games in an overlay (Ctrl+Q to detach)",
+		description: "Play NES games in pi (Ctrl+Q to detach)",
 		handler: async (args, ctx) => {
 			if (!ctx.hasUI) {
 				ctx.ui.notify("NES requires interactive mode", "error");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-nes",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "NES emulator extension for pi",
   "keywords": [
     "pi-package",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -48,9 +48,9 @@ describe("config", () => {
 			assert.strictEqual(config.videoFilter, "ntsc-composite");
 		});
 
-		test("defaults invalid videoFilter to off", () => {
+		test("defaults invalid videoFilter to the configured default", () => {
 			const config = normalizeConfig({ videoFilter: "crt" });
-			assert.strictEqual(config.videoFilter, "off");
+			assert.strictEqual(config.videoFilter, DEFAULT_CONFIG.videoFilter);
 		});
 
 		test("clamps pixelScale to valid range", () => {


### PR DESCRIPTION
## Summary
- run image mode in the main custom UI instead of a pi overlay
- keep text mode in the classic overlay path
- bump package version to `0.2.40`
- fix the stale `videoFilter` unit test expectation that surfaced while running tests

## Why
Ghostty renders the Kitty image sequence correctly, but `pi-nes` would show a black image area when image mode was mounted through pi's overlay path. Local repro showed the framebuffer and Kitty transport were fine; switching image mode out of the overlay path fixed the issue.

Closes #13

## Verification
- `npm test`
- manually launched `/nes /Users/thomasmustier/roms/Legend of Zelda.nes` in Ghostty with the local extension installed in an isolated Pi config; image mode rendered correctly
