### PR TITLE
docs: clarify updating, audio rebuilds, and duplicate installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ Or from git:
 pi install git:github.com/tmustier/pi-nes
 ```
 
+## Updating
+
+If you installed from npm:
+
+```bash
+pi update npm:@tmustier/pi-nes
+```
+
+Then fully restart `pi`.
+
+### Updating from older versions
+
+- No config migration is required.
+- On Kitty-compatible terminals (Ghostty, Kitty, WezTerm), image mode now opens in pi's main custom UI instead of an overlay.
+- Text mode still uses the classic overlay experience.
+
 ## Quick Start
 
 ```bash
@@ -110,6 +126,33 @@ Saves are flushed on quit and periodically during play.
 
 Set `"renderer": "text"` if you prefer the ANSI renderer or want the classic overlay experience.
 
+## Audio after npm install or update
+
+The published package works without audio by default. To enable audio, rebuild the native core with the `audio-cpal` feature.
+
+First, find the installed `@tmustier/pi-nes` path:
+
+```bash
+pi list
+```
+
+Then `cd` into the printed install path plus `extensions/nes/native/nes-core`, and rebuild:
+
+```bash
+npm install
+npm run build:audio
+```
+
+For a standard global npm install, that path is typically:
+
+```bash
+cd "$(npm root -g)/@tmustier/pi-nes/extensions/nes/native/nes-core"
+```
+
+Then enable audio in `/nes-config`.
+
+If you update `@tmustier/pi-nes` later, run `build:audio` again because the native binary may be replaced during the update.
+
 ## Limitations
 
 - **Audio is opt-in** — Requires building the native core with `audio-cpal` and setting `enableAudio: true`
@@ -147,4 +190,23 @@ npm install && npm run build
 Run locally:
 ```bash
 pi --extension /path/to/pi-nes
+```
+
+## Troubleshooting
+
+### `/nes` or `/nes-config` shows up twice
+
+You likely have both an npm install and a local/path install enabled.
+
+Check installed packages:
+
+```bash
+pi list
+```
+
+Then remove the extra one:
+
+```bash
+pi remove <source>      # for entries under "User packages"
+pi remove -l <source>   # for entries under "Project packages"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmustier/pi-nes",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "NES emulator extension for pi",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
- add a dedicated README section for updating from npm
- document that image mode now opens in pi's main custom UI while text mode stays in the overlay flow
- add explicit audio rebuild instructions for npm installs and updates
- add a troubleshooting note for duplicate `/nes` command entries
- bump package version to `0.2.41` so the refreshed README is reflected on npm

## Verification
- `npm test`
